### PR TITLE
Minor adjustments

### DIFF
--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -79,7 +79,7 @@ export default {
 			element.setAttribute(
 				"href",
 				"data:text/json;charset=utf-8," +
-					encodeURIComponent(JSON.stringify(this.week))
+					encodeURIComponent(JSON.stringify(this.week, null, 2))
 			);
 			element.setAttribute("download", this.exportName);
 			element.style.display = "none";

--- a/src/components/SubjectDisplay.vue
+++ b/src/components/SubjectDisplay.vue
@@ -13,7 +13,7 @@
 				:disabled="password === ''"
 				@click="copy"
 			>
-				copy password
+				Copy password
 			</button>
 			<a :href="link" target="_blank"><button>Join</button></a>
 		</div>


### PR DESCRIPTION
- Fixes spelling irregularity (from   _**c**opy password_   to   _**C**opy password_   since _**J**oin_   also starts with a capital letter)
- Enables pretty printing for JSON exports which allows an easier modification due to better readibilty